### PR TITLE
add builddirectory/include to include directories when building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ configure_file (
   "${PROJECT_BINARY_DIR}/include/FastBDT.h"
 )
 
-include_directories("${PROJECT_SOURCE_DIR}/include/")
+include_directories("${PROJECT_SOURCE_DIR}/include/" "${PROJECT_BINARY_DIR}/include/")
 
 set(FastBDT_SOURCES
   "${PROJECT_SOURCE_DIR}/src/FastBDT.cxx"


### PR DESCRIPTION
Fix compiler errors for out-of-source builds in acaf08c0736946814f2f7ca9dfd962ea5.
FastBDT.h is generated by cmake into build directory, which needs to be
added to include directories to let compiler find it.