### PR TITLE
Include libraries in python package and fix path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ if (PYTHON)
                        DEPENDS ${DEPS})
 
     add_custom_target(target ALL DEPENDS ${OUTPUT})
+    add_custom_command(TARGET FastBDT_shared FastBDT_CInterface POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:FastBDT_shared> $<TARGET_FILE:FastBDT_CInterface> "${PROJECT_SOURCE_DIR}/PyFastBDT/")
 
     install(CODE "execute_process(COMMAND ${PYTHON} ${PROJECT_SOURCE_DIR}/setup.py install --prefix=${CMAKE_INSTALL_PREFIX})")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,8 @@ if (PYTHON)
                        DEPENDS ${DEPS})
 
     add_custom_target(target ALL DEPENDS ${OUTPUT})
-    add_custom_command(TARGET FastBDT_shared FastBDT_CInterface POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:FastBDT_shared> $<TARGET_FILE:FastBDT_CInterface> "${PROJECT_SOURCE_DIR}/PyFastBDT/")
+    add_custom_command(TARGET FastBDT_shared POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:FastBDT_shared> "${PROJECT_SOURCE_DIR}/PyFastBDT/")
+    add_custom_command(TARGET FastBDT_CInterface POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:FastBDT_CInterface> "${PROJECT_SOURCE_DIR}/PyFastBDT/")
 
     install(CODE "execute_process(COMMAND ${PYTHON} ${PROJECT_SOURCE_DIR}/setup.py install --prefix=${CMAKE_INSTALL_PREFIX})")
 endif()

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include libFastBDT_CInterface.so
+include libFastBDT_shared.so

--- a/PyFastBDT/FastBDT.py
+++ b/PyFastBDT/FastBDT.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 import numpy as np
 
 import ctypes
@@ -8,15 +9,7 @@ c_double_p = ctypes.POINTER(ctypes.c_double)
 c_float_p = ctypes.POINTER(ctypes.c_float)
 c_uint_p = ctypes.POINTER(ctypes.c_uint)
 
-import os
-
-# Apparently find_library does not work as I expected
-#FastBDT_library_path = ctypes.util.find_library('FastBDT_CInterface')
-#print('Try to load ', FastBDT_library_path)
-#FastBDT_library = ctypes.cdll.LoadLibrary(FastBDT_library_path)
-
-FastBDT_library =  ctypes.cdll.LoadLibrary(os.getcwd() + '/libFastBDT_CInterface.so')
-print('Loaded ', FastBDT_library)
+FastBDT_library =  ctypes.cdll.LoadLibrary(os.path.join(os.path.dirname(__file__),'libFastBDT_CInterface.so'))
 
 FastBDT_library.Create.restype = ctypes.c_void_p
 FastBDT_library.Delete.argtypes = [ctypes.c_void_p]

--- a/setup.py.in
+++ b/setup.py.in
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(name='PyFastBDT',
-      version='${PACKAGE_VERSION}',
-      package_dir={ '': '${CMAKE_CURRENT_SOURCE_DIR}' },
-      packages=['PyFastBDT'])
-
+      version='${FastBDT_VERSION_MAJOR}.${FastBDT_VERSION_MINOR}',
+      packages=['PyFastBDT'],
+      package_data={'PyFastBDT': ['*.so']},
+     )


### PR DESCRIPTION
This fix makes it easier to install the PyFastBDT python package into a virtualenv.
The only thing that's missing is a command somewhere in cmake to copy the shared libraries to the python package path because distutils can only look there.
`cp *.so PyFastBDT/`